### PR TITLE
Fixed typo build config file

### DIFF
--- a/build/example.build.config
+++ b/build/example.build.config
@@ -12,4 +12,4 @@ keystore.file = /path/to/your/certificate/selfSignedTestCert.p12
 keystore.password = selfSignedTestPassword
 
 # Location of the android sdk
-android.adk = path/to/your/android-sdk/platforms/android-8
+android.sdk = path/to/your/android-sdk/platforms/android-8


### PR DESCRIPTION
android.sdk was mistyped as android.adk
